### PR TITLE
fix: Clean up edit plan UI and fix plan loading in ActiveWorkout

### DIFF
--- a/src/pages/ActiveWorkout.tsx
+++ b/src/pages/ActiveWorkout.tsx
@@ -7,7 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { Play, Pause, Square, CheckCircle, Clock, Plus, Minus } from "lucide-react";
 import { mockWorkoutPlans } from "@/data/mockData";
-import { getPlanById, addCompletedWorkout, getLastWeightForExercise, saveLastWeight } from "@/data/storage";
+import { getPlanById, addCompletedWorkout, getLastWeightForExercise, saveLastWeight, getPlans } from "@/data/storage";
 import { CompletedWorkout } from "@/data/mockData";
 import { useToast } from "@/hooks/use-toast";
 import { PageTransition, FadeIn } from "@/components/ui/page-transition";
@@ -22,7 +22,8 @@ const ActiveWorkout = () => {
   useEffect(() => {
     const loadPlan = async () => {
       if (planId) {
-        const found = await getPlanById(planId, mockWorkoutPlans);
+        const currentPlans = await getPlans(mockWorkoutPlans);
+        const found = await getPlanById(planId, currentPlans);
         if (found) {
           // Load last weights for each exercise
           const planWithLastWeights = {

--- a/src/pages/EditWorkoutPlan.tsx
+++ b/src/pages/EditWorkoutPlan.tsx
@@ -220,18 +220,7 @@ const EditWorkoutPlan = () => {
         </CardContent>
       </Card>
 
-      <div className="flex gap-4 items-center">
-        <div className="flex-1 text-sm text-muted-foreground">
-          💡 As alterações são guardadas automaticamente
-        </div>
-        <Button 
-          onClick={savePlan}
-          variant="outline"
-          className="border-fitness-primary/20 text-fitness-primary hover:bg-fitness-primary/10"
-        >
-          <Save className="h-4 w-4 mr-2" />
-          Guardar Agora
-        </Button>
+      <div className="flex gap-4">
         <Button 
           variant="outline"
           onClick={() => navigate("/")}


### PR DESCRIPTION
 UI IMPROVEMENTS:
- Removed 'As alterações são guardadas automaticamente' text from edit plan page
- Removed 'Guardar Agora' button since auto-save is working
- Simplified button layout with only 'Voltar aos Planos' and 'Remover Plano'

 BUG FIX:
- Fixed 'Plano não encontrado' issue when starting workout from custom plans
- ActiveWorkout now loads from user's actual plans instead of mock data
- Custom plans created from scratch now work properly in workouts

The edit plan page is now cleaner and custom plans work correctly in all scenarios.